### PR TITLE
Sphinx docs

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,0 +1,53 @@
+name: Sphinx
+
+on:
+  push:
+    branches: [ master ]
+  
+  workflow_dispatch:
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    environment: deployment
+
+    steps:
+    
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 black mypy pytest pytest-cov
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install -e .
+
+    - name: Install documentation dependencies
+      run: |
+        pip install .[build_sphinx]
+    
+    - name: Build documentation
+      run: |
+        python setup.py build_sphinx
+        cp -rv build/sphinx/html/* docs/
+    
+    - name: Publish to Github pages
+      env:
+        USER_EMAIL: "t1000@skynet.ai"
+        USER_NAME: "github-actions"
+      run: |
+        git checkout -b gh-pages-temp
+        git config user.name ${USER_NAME}
+        git config user.email ${USER_EMAIL}
+        git add -A
+        git commit -m "Deploy documentation"
+        git push -f origin HEAD:gh-pages

--- a/README.md
+++ b/README.md
@@ -46,13 +46,31 @@ The files can be saved to a local file with `filesave`.
 
 Run `search_history()` to see the search history of the fetcher.
 
-See the run_profet.ipynb notebook for usage examples.
+#### Example usage:
+
+ ```
+Python3 
+
+$ import profet as pf
+$ fetcher = pf.Fetcher()
+$ fetcher.set_directory("/path/to/directory/folder")
+$ fetcher.get_file(uniprot_id = "P61316", filetype = "pdb", filesave = True, db = "alphafold")
+
+$ fetcher.search_history()
+{'P61316': ['pdb', 'alphafold']}
+```
+
+Loads Profet and the file-fetcher, then specifies a directory to save the files at.
+Lastly, downloads the protein with uniprod ID "P61316", in pdb format from the Alphafold databank and saves it in the specified directory.
+
+For more detailed examples consult the following [Python notebook](./run_profet.ipynb).
 
 ### Documentation
 
 You can find more documentation including a description of the python api [here](https://alan-turing-institute.github.io/profet/).
 
 ### Issues and Feature Requests
+
 If you run into an issue, or if you find a workaround for an existing issue, we would very much appreciate it if you could post your question or code as a [GitHub issue](https://github.com/alan-turing-institute/profet/issues). 
 
 ### Contributions

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Run `search_history()` to see the search history of the fetcher.
 
 See the run_profet.ipynb notebook for usage examples.
 
+### Documentation
+
+You can find more documentation including a description of the python api [here](https://alan-turing-institute.github.io/profet/).
+
 ### Issues and Feature Requests
 If you run into an issue, or if you find a workaround for an existing issue, we would very much appreciate it if you could post your question or code as a [GitHub issue](https://github.com/alan-turing-institute/profet/issues). 
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Python 3  **pro**tein structure **fet**cher. Retrieves the cif or pdb files fr
 
 [![Building](https://github.com/alan-turing-insitute/profet/actions/workflows/python-package.yml/badge.svg)](https://github.com/alan-turing-insitute/profet/actions/workflows/python-package.yml)
 [![Publishing](https://github.com/alan-turing-insitute/profet/actions/workflows/python-publish.yml/badge.svg)](https://github.com/alan-turing-insitute/profet/actions/workflows/python-publish.yml)
+[![Documentation](https://github.com/alan-turing-insitute/profet/actions/workflows/sphinx.yml/badge.svg)](https://github.com/alan-turing-insitute/profet/actions/workflows/sphinx.yml)
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The files can be saved to a local file with `filesave`.
 
 Run `search_history()` to see the search history of the fetcher.
 
+See the run_profet.ipynb notebook for usage examples.
+
 ### Issues and Feature Requests
 If you run into an issue, or if you find a workaround for an existing issue, we would very much appreciate it if you could post your question or code as a [GitHub issue](https://github.com/alan-turing-institute/profet/issues). 
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,17 @@
+Python API
+==========
+
+Profet's functionality is accessed mainly through the :class:`profet.Fetcher`
+class documented below. Lower level functionality for each database in profet
+can be accessed through the :class:`profet.alphafold.Alphafold_DB` and
+:class:`profet.pdb.PDB_DB` classes.
+
+.. autoclass:: profet.Fetcher
+  :members:
+
+.. autoclass:: profet.alphafold.Alphafold_DB
+  :members:
+
+.. autoclass:: profet.pdb.PDB_DB
+  :members:
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,60 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+import profet
+
+sys.path.insert(0, os.path.abspath("../"))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "profet"
+copyright = "2023, Beatriz Costa Gomes"
+author = "Beatriz Costa Gomes"
+
+# The full version, including alpha/beta/rc tags
+release = profet.__version__
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinxarg.ext",
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,29 @@
+.. profet documentation master file, created by
+   sphinx-quickstart on Mon Jul 10 12:06:42 2023.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to profet's documentation!
+==================================
+
+Profet is a Python 3  **pro**\ tein structure **fet**\ cher. It retrieves the cif or
+pdb files from either the RCSB Protein Data Bank (`PDB <https://www.rcsb.org>`_),
+using `pypdb <https://github.com/williamgilpin/pypdb>`_) or
+`Alphafold <http://alphafold.ebi.ac.uk/>`_ using the
+`Uniprot <http://uniprot.org/>`_ ID. 
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   installation
+   usage
+   api
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,0 +1,23 @@
+Installation
+============
+
+Install `profet` using pip:
+
+.. code-block:: bash
+  
+  pip install profet
+
+To install the development version, which contains the latest features and
+fixes, install directly from GitHub using:
+
+.. code-block:: bash
+
+  pip install git+git://github.com/alan-turing-institute/profet`
+
+Test the installation, navigate to the root directory and run
+
+.. code-block:: bash
+  
+  pytest
+  
+This code has been designed and tested for Python 3.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,0 +1,24 @@
+Usage
+=====
+
+This package can be used to retrieve the available protein structure from any
+Uniprot ID. 
+
+The :class:`profet.Fetcher` class can search the IDs in both PDB and Alphafold, and saves the
+search results in a dictionary.
+
+:meth:`profet.Fetcher.get_file` returns the structure corresponding to
+`uniprot_id` in the defined `filetype:` (default as `'pdb'`, option as
+`'cif'`), searching first in the defaulted database `db` (default as `'pdb'`,
+option as `'alphafold'`).  The files can be saved to a local file with
+`filesave`.
+
+:meth:`profet.Fetcher.set_default_db` changes the default database into the
+given one between `'pdb'` and `'alphafold'`.
+
+:meth:`profet.Fetcher.set_directory` changes the directory where the files are
+saved. Files save as `<directory>/<id>.<filetype>`.
+
+Run :meth:`profet.Fetcher.search_history()` to see the search history of the fetcher.
+
+See the run_profet.ipynb notebook for usage examples.

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,10 @@ install_requires =
 dev =
   pytest
   pytest-cov
+build_sphinx =
+  sphinx
+  sphinx_rtd_theme
+  sphinx-argparse
 
 
 [tool:pytest]


### PR DESCRIPTION
This pull request adds sphinx documentation with auto generated python api docs.

I've also added a few changes to the README and added a workflow to automatically generate the sphinx docs and push to the gh_pages branch. 

After the sphinx action is run the gh_pages branch will then be used to populate alan-turing-insitute.github.io/profet with the sphinx documentation.