### PR TITLE
Add file cache functionality

### DIFF
--- a/_tests/test_io.py
+++ b/_tests/test_io.py
@@ -4,6 +4,7 @@ import profet
 from profet import Fetcher
 from profet import alphafold
 from profet import pdb
+from collections import defaultdict
 
 ONLY_ALPHAFOLD = "F4HvG8"
 ONLY_PDB = "7U6Q"
@@ -67,3 +68,50 @@ def test_fetcher_get_file(tmpdir, test_id):
     fetcher.set_directory(str(tmpdir))
     filename, contents = fetcher.get_file(pdb_id, filesave=True)
     assert os.path.exists(filename)
+
+
+def test_cache(tmpdir):
+    cache = profet.cache.PDBFileCache(directory=tmpdir)
+
+    filename = cache.path("4V5D", "cif")
+    assert filename == os.path.join(tmpdir, "4v5d.cif")
+
+    filename = cache.path("4V5D", "pdb")
+    assert filename == os.path.join(tmpdir, "4v5d.pdb")
+
+    cache["4V5D"] = ("cif", "4V5D cif data")
+    cache["1U2P"] = ("pdb", "1U2P pdb data")
+    cache["1U2P"] = ("cif", "1U2P cif data")
+
+    assert len(cache.find("2J3K")) == 0
+    assert len(cache.find("4V5D")) == 1
+    assert len(cache.find("1U2P")) == 2
+
+    assert "2J3K" not in cache
+    assert "4v5d" in cache
+    assert "1u2p" in cache
+
+    filename = cache["4v5d"]
+    assert filename == os.path.join(tmpdir, "4v5d.cif")
+
+    with open(filename) as infile:
+        text = infile.read()
+        assert text == "4V5D cif data"
+
+    filename = cache["1u2p"]
+    assert filename == os.path.join(tmpdir, "1u2p.pdb")
+
+    with open(filename) as infile:
+        text = infile.read()
+        assert text == "1U2P pdb data"
+
+    items = defaultdict(list)
+    for identifier, filename in cache.items():
+        items[identifier].append(filename)
+
+    assert len(items) == 2
+    assert len(items["4v5d"]) == 1
+    assert len(items["1u2p"]) == 2
+    assert os.path.join(tmpdir, "4v5d.cif") in items["4v5d"]
+    assert os.path.join(tmpdir, "1u2p.cif") in items["1u2p"]
+    assert os.path.join(tmpdir, "1u2p.pdb") in items["1u2p"]

--- a/profet/alphafold.py
+++ b/profet/alphafold.py
@@ -140,4 +140,4 @@ class Alphafold_DB:
             file = requests.get(url)
 
         # Return the filename and file contents
-        return filetype, file.text
+        return uniprot_id, filetype, file.text

--- a/profet/alphafold.py
+++ b/profet/alphafold.py
@@ -109,8 +109,6 @@ class Alphafold_DB:
         self,
         uniprot_id: str,
         filetype: str = "pdb",
-        filesave: bool = False,
-        filedir: str = "default",
     ) -> tuple:
         """
         Returns pdb/cif as strings, saves to file if requested.
@@ -118,7 +116,6 @@ class Alphafold_DB:
         Args:
             uniprot_id: ID from Uniprot
             filetype: File type to be retrieved: cif, pdb
-            filesave: Option to save into a file
             filedir: The directory to save the data
 
         Returns:
@@ -142,12 +139,5 @@ class Alphafold_DB:
             url = self.get_file_url(uniprot_id, filetype)
             file = requests.get(url)
 
-        # Update the filename
-        filedir = filedir + "." + filetype
-
-        # Optionally save the data to disk
-        if filesave:
-            open(filedir, "w").write(file.text)
-
         # Return the filename and file contents
-        return filedir, file.text
+        return filetype, file.text

--- a/profet/cache.py
+++ b/profet/cache.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import os
 
 
@@ -79,7 +78,7 @@ class PDBFileCache(object):
         """
         return len(self.find(uniprot_id)) > 0
 
-    def __getitem__(self, uniprot_id: str) -> Optional[tuple]:
+    def __getitem__(self, uniprot_id: str) -> str:
         """
         Get the full path to the item
 
@@ -91,7 +90,7 @@ class PDBFileCache(object):
 
         """
         if uniprot_id not in self:
-            return None
+            raise RuntimeError("%s not in cache" % uniprot_id)
         return self.find(uniprot_id)[0]
 
     def __setitem__(self, uniprot_id: str, item: tuple):

--- a/profet/cache.py
+++ b/profet/cache.py
@@ -34,20 +34,20 @@ class PDBFileCache(object):
         if not os.path.exists(self.directory):
             os.mkdir(self.directory)
 
-    def path(self, uniprot_id: str, filetype: str = ".pdb") -> str:
+    def path(self, uniprot_id: str, filetype: str = "pdb") -> str:
         """
         Get the proposed path
 
         Args:
             uniprot_id: The uniprot id
-            filetype: Either .pdb or .cif
+            filetype: Either pdb or cif
 
         Returns:
             The absolute path
 
         """
-        assert filetype in [".pdb", ".cif"]
-        return os.path.join(self.directory, uniprot_id.lower()) + filetype
+        assert filetype in ["pdb", "cif"]
+        return os.path.join(self.directory, uniprot_id.lower()) + "." + filetype
 
     def find(self, uniprot_id: str) -> list:
         """
@@ -63,7 +63,7 @@ class PDBFileCache(object):
         return [
             filename
             for filename in [
-                self.path(uniprot_id, filetype) for filetype in [".pdb", ".cif"]
+                self.path(uniprot_id, filetype) for filetype in ["pdb", "cif"]
             ]
             if os.path.exists(filename)
         ]
@@ -109,8 +109,14 @@ class PDBFileCache(object):
         # Get the item components
         filetype, filedata = item
 
+        # Bytes or string
+        if isinstance(filedata, (bytes, bytearray)):
+            mode = "wb"
+        else:
+            mode = "w"
+
         # Write the file
-        with open(self.path(uniprot_id, filetype), "w") as outfile:
+        with open(self.path(uniprot_id, filetype), mode) as outfile:
             outfile.write(filedata)
 
     def items(self):

--- a/profet/cache.py
+++ b/profet/cache.py
@@ -12,9 +12,7 @@ class PDBFileCache(object):
         """
         Initialise the cache object with the directory
 
-        If directory is None then the PDB_CACHE environment variable is
-        checked. If the environment variable is empty then the cache is set to
-        ~/.cache/pdb
+        If directory is None then the cache is set to ~/.cache/pdb
 
         Args:
             directory: The cache directory

--- a/profet/cache.py
+++ b/profet/cache.py
@@ -1,0 +1,124 @@
+from typing import Optional
+import os
+
+
+class PDBFileCache(object):
+    """
+    A class to cache the PDB files
+
+    """
+
+    def __init__(self, directory: str = None):
+        """
+        Initialise the cache object with the directory
+
+        If directory is None then the PDB_CACHE environment variable is
+        checked. If the environment variable is empty then the cache is set to
+        ~/.cache/pdb
+
+        Args:
+            directory: The cache directory
+
+        """
+
+        # Set the cache directory
+        self.directory = os.path.abspath(
+            directory
+            if directory is not None
+            else os.path.expanduser(
+                os.getenv("PDB_CACHE", os.path.join("~", ".cache", "pdb"))
+            )
+        )
+
+        # Create the directory if it doesn't exist
+        if not os.path.exists(self.directory):
+            os.mkdir(self.directory)
+
+    def path(self, uniprot_id: str, filetype: str = ".pdb") -> str:
+        """
+        Get the proposed path
+
+        Args:
+            uniprot_id: The uniprot id
+            filetype: Either .pdb or .cif
+
+        Returns:
+            The absolute path
+
+        """
+        assert filetype in [".pdb", ".cif"]
+        return os.path.join(self.directory, uniprot_id.lower()) + filetype
+
+    def find(self, uniprot_id: str) -> list:
+        """
+        Find all items matching the uniprot_id
+
+        Args:
+            uniprot_id: The uniprot id
+
+        Returns:
+            The list of matching items
+
+        """
+        return [
+            filename
+            for filename in [
+                self.path(uniprot_id, filetype) for filetype in [".pdb", ".cif"]
+            ]
+            if os.path.exists(filename)
+        ]
+
+    def __contains__(self, uniprot_id: str) -> bool:
+        """
+        Check if the filename is in the cache
+
+        Args:
+            uniprot_id: The uniprot id
+
+        Returns:
+            True/False if the filename is in the cache
+
+        """
+        return len(self.find(uniprot_id)) > 0
+
+    def __getitem__(self, uniprot_id: str) -> Optional[tuple]:
+        """
+        Get the full path to the item
+
+        Args:
+            uniprot_id: The uniprot id
+
+        Returns:
+            The absolute path to the item
+
+        """
+        if uniprot_id not in self:
+            return None
+        return self.find(uniprot_id)[0]
+
+    def __setitem__(self, uniprot_id: str, item: tuple):
+        """
+        Write the file into the cache
+
+        Args:
+            uniprot_id: The uniprot id
+            item: (The file type, The file data)
+
+        """
+
+        # Get the item components
+        filetype, filedata = item
+
+        # Write the file
+        with open(self.path(uniprot_id, filetype), "w") as outfile:
+            outfile.write(filedata)
+
+    def items(self):
+        """
+        Iterate through the items in the cache
+
+        """
+        for filename in os.listdir(self.directory):
+            if filename.endswith(".cif") or filename.endswith(".pdb"):
+                uniprot_id, filetype = os.path.splitext(filename)
+                yield uniprot_id, self.path(uniprot_id, filetype)

--- a/profet/cache.py
+++ b/profet/cache.py
@@ -25,8 +25,8 @@ class PDBFileCache(object):
         self.directory = os.path.abspath(
             directory
             if directory is not None
-            else os.path.expanduser(
-                os.getenv("PDB_CACHE", os.path.join("~", ".cache", "pdb"))
+            else os.path.abspath(
+                os.path.expanduser(os.path.join("~", ".cache", "pdb"))
             )
         )
 

--- a/profet/cache.py
+++ b/profet/cache.py
@@ -125,4 +125,4 @@ class PDBFileCache(object):
         for filename in os.listdir(self.directory):
             if filename.endswith(".cif") or filename.endswith(".pdb"):
                 uniprot_id, filetype = os.path.splitext(filename)
-                yield uniprot_id, self.path(uniprot_id, filetype)
+                yield uniprot_id, self.path(uniprot_id, filetype[1:])

--- a/profet/pdb.py
+++ b/profet/pdb.py
@@ -41,8 +41,6 @@ class PDB_DB:
         self,
         uniprot_id: str,
         filetype: str = "pdb",
-        filesave: bool = False,
-        filedir: str = "default",
     ) -> tuple:
         """
         Returns pdb/cif as strings, saves to file if requested
@@ -50,7 +48,6 @@ class PDB_DB:
         Args:
             uniprot_id: ID from Uniprot
             filetype: File type to be retrieved: cif, pdb
-            filesave: Option to save into a file
             filedir: The directory to save the data
 
         Returns:
@@ -79,12 +76,5 @@ class PDB_DB:
                 pdb_id, PDBFileType(filetype), compression=True
             )
 
-        # Update the filename
-        filedir = filedir + "." + filetype
-
-        # Optionally save the data to disk
-        if filesave:
-            open(filedir, "wb").write(filedata)
-
         # Return the filename and file contents
-        return filedir, filedata
+        return filetype, filedata

--- a/profet/pdb.py
+++ b/profet/pdb.py
@@ -76,5 +76,11 @@ class PDB_DB:
                 pdb_id, PDBFileType(filetype), compression=True
             )
 
-        # Return the filename and file contents
-        return filetype, filedata
+        # If pdb is not the same then add the pdb id to the uniprot id as the identifier
+        if pdb_id.lower() != uniprot_id.lower():
+            identifier = uniprot_id + "_" + pdb_id
+        else:
+            identifier = uniprot_id
+
+        # Return the identifier, file type and file contents
+        return identifier, filetype, filedata

--- a/profet/profet.py
+++ b/profet/profet.py
@@ -1,5 +1,7 @@
 from .alphafold import Alphafold_DB
 from .pdb import PDB_DB
+from .cache import PDBFileCache
+import os
 
 
 class Fetcher:
@@ -9,7 +11,7 @@ class Fetcher:
 
     """
 
-    def __init__(self, main_db: str = "pdb"):
+    def __init__(self, main_db: str = "pdb", save_directory: str = None):
         """
         Initialise the fetcher
 
@@ -18,7 +20,7 @@ class Fetcher:
         self.pdb = PDB_DB()
         self.alpha = Alphafold_DB()
         self.search_results = {}  # type: ignore
-        self.save_directory = ""
+        self.save_directory = save_directory
 
     def check_db(self, uniprot_id: str) -> list:
         """
@@ -43,7 +45,6 @@ class Fetcher:
         self,
         prot_id: str,
         filetype: str = "pdb",
-        filesave: bool = False,
         db: str = "pdb",
     ) -> tuple:
         """
@@ -52,32 +53,26 @@ class Fetcher:
         Args:
             uniprot_id: ID from Uniprot.
             filetype: File type to be retrieved: cif, pdb.
-            filesave: Option to save into a file.
             db: database from which to retrieve the file.
 
         Returns:
             Tuple containing the filename and file from the database
 
         """
-        save_dir = self.save_directory + prot_id
         if db == "pdb":
-            filename, filedata = self.pdb.get_pdb(
+            filetype, filedata = self.pdb.get_pdb(
                 prot_id,
                 filetype=filetype,
-                filesave=filesave,
-                filedir=save_dir,
             )
         elif db == "alphafold":
-            filename, filedata = self.alpha.get_pdb(
+            filetype, filedata = self.alpha.get_pdb(
                 prot_id,
                 filetype=filetype,
-                filesave=filesave,
-                filedir=save_dir,
             )
         else:
             raise RuntimeError("Unknown db: %s" % db)
 
-        return filename, filedata
+        return filetype, filedata
 
     def get_file(
         self,
@@ -102,31 +97,48 @@ class Fetcher:
             2. File from the database, or None if it is not available in any database.
 
         """
-        self.search_results[uniprot_id] = self.check_db(uniprot_id)
-        if len(self.search_results[uniprot_id]):
-            if db in self.search_results[uniprot_id]:
-                print("Structure available on defaulted database: " + db)
-                filename, filedata = self.file_from_db(
-                    prot_id=uniprot_id,
-                    filetype=filetype,
-                    filesave=filesave,
-                    db=db,
-                )
-            else:
-                for item in self.search_results[uniprot_id]:
-                    print(
-                        "Structure available in alternative database: " + item
-                    )
-                    filename, filedata = self.file_from_db(
+
+        # Get the PDB cache
+        cache = PDBFileCache(directory=self.save_directory)
+
+        # If the file is already downloaded then use that, otherwise search in
+        # the PDB or alphafold databases
+        if uniprot_id in cache:
+            filename = cache[uniprot_id]
+            with open(filename) as infile:
+                filedata = infile.read()
+        else:
+            self.search_results[uniprot_id] = self.check_db(uniprot_id)
+            if len(self.search_results[uniprot_id]):
+                if db in self.search_results[uniprot_id]:
+                    print("Structure available on defaulted database: " + db)
+                    filetype, filedata = self.file_from_db(
                         prot_id=uniprot_id,
                         filetype=filetype,
-                        filesave=filesave,
-                        db=item,
+                        db=db,
                     )
-        else:
-            raise RuntimeError(
-                "Structure %s not available on any database" % uniprot_id
-            )
+                else:
+                    for item in self.search_results[uniprot_id]:
+                        print(
+                            "Structure available in alternative database: "
+                            + item
+                        )
+                        filetype, filedata = self.file_from_db(
+                            prot_id=uniprot_id,
+                            filetype=filetype,
+                            db=item,
+                        )
+            else:
+                raise RuntimeError(
+                    "Structure %s not available on any database" % uniprot_id
+                )
+
+            # Optionally save the data
+            if filesave:
+                cache[uniprot_id] = (filetype, filedata)
+                filename = cache[uniprot_id]
+            else:
+                filename = None
 
         # Return the filename and file
         return filename, filedata
@@ -147,9 +159,7 @@ class Fetcher:
             new_dir: The directory to save data
 
         """
-        if not new_dir.endswith("/"):
-            new_dir = new_dir + "/"
-        self.save_directory = new_dir
+        self.save_directory = os.path.abspath(os.path.expanduser(new_dir))
 
     def get_default_db(self) -> str:
         """

--- a/profet/profet.py
+++ b/profet/profet.py
@@ -59,20 +59,9 @@ class Fetcher:
             Tuple containing the filename and file from the database
 
         """
-        if db == "pdb":
-            filetype, filedata = self.pdb.get_pdb(
-                prot_id,
-                filetype=filetype,
-            )
-        elif db == "alphafold":
-            filetype, filedata = self.alpha.get_pdb(
-                prot_id,
-                filetype=filetype,
-            )
-        else:
-            raise RuntimeError("Unknown db: %s" % db)
-
-        return filetype, filedata
+        return {"pdb": self.pdb.get_pdb, "alphafold": self.alpha.get_pdb}[db](
+            prot_id, filetype=filetype
+        )
 
     def get_file(
         self,
@@ -112,7 +101,7 @@ class Fetcher:
             if len(self.search_results[uniprot_id]):
                 if db in self.search_results[uniprot_id]:
                     print("Structure available on defaulted database: " + db)
-                    filetype, filedata = self.file_from_db(
+                    identifier, filetype, filedata = self.file_from_db(
                         prot_id=uniprot_id,
                         filetype=filetype,
                         db=db,
@@ -123,7 +112,7 @@ class Fetcher:
                             "Structure available in alternative database: "
                             + item
                         )
-                        filetype, filedata = self.file_from_db(
+                        identifier, filetype, filedata = self.file_from_db(
                             prot_id=uniprot_id,
                             filetype=filetype,
                             db=item,
@@ -135,8 +124,8 @@ class Fetcher:
 
             # Optionally save the data
             if filesave:
-                cache[uniprot_id] = (filetype, filedata)
-                filename = cache[uniprot_id]
+                cache[identifier] = (filetype, filedata)
+                filename = cache[identifier]
             else:
                 filename = None
 


### PR DESCRIPTION
This pull request adds a file cache. When a file is requested, first a cache folder (default ~/.cache/pdb) is checked. If the file exists either as a ${UNIPROT_ID}.cif or ${UNIPROT_ID}.pdb file, then that file is returned. Otherwise the file is downloaded.

The cache is wrapped in a class within profet.cache.PDBFileCache. You can set the cache programmatically by setting the save_directory in profet. 
