### PR TITLE
Enable ability to download multiple versions

### DIFF
--- a/_tests/test_io.py
+++ b/_tests/test_io.py
@@ -119,6 +119,24 @@ def test_cache(tmpdir):
     assert os.path.join(tmpdir, "1u2p.pdb") in items["1u2p"]
 
 
+def test_cache_download_cif_and_pdb(tmpdir):
+
+    fetcher = profet.Fetcher()
+    fetcher.set_directory(str(tmpdir))
+
+    fetcher.get_file(uniprot_id = "P0A855", filetype = "cif", filesave = True, db = "alphafold")
+
+    fetcher.get_file(uniprot_id = "P0A855", filetype = "pdb", filesave = True, db = "alphafold")
+
+    assert os.path.exists(os.path.join(tmpdir, "p0a855.cif"))
+    assert os.path.exists(os.path.join(tmpdir, "p0a855.pdb"))
+
+    items = defaultdict(list)
+    for identifier, filename in fetcher.cache().items():
+        items[identifier].append(filename)
+    assert len(items["p0a855"]) == 2
+
+
 @pytest.mark.parametrize("test_id", get_test_ids())
 def test_command_line_main(tmpdir, test_id):
     source, pdb_id = test_id

--- a/_tests/test_io.py
+++ b/_tests/test_io.py
@@ -120,13 +120,16 @@ def test_cache(tmpdir):
 
 
 def test_cache_download_cif_and_pdb(tmpdir):
-
     fetcher = profet.Fetcher()
     fetcher.set_directory(str(tmpdir))
 
-    fetcher.get_file(uniprot_id = "P0A855", filetype = "cif", filesave = True, db = "alphafold")
+    fetcher.get_file(
+        uniprot_id="P0A855", filetype="cif", filesave=True, db="alphafold"
+    )
 
-    fetcher.get_file(uniprot_id = "P0A855", filetype = "pdb", filesave = True, db = "alphafold")
+    fetcher.get_file(
+        uniprot_id="P0A855", filetype="pdb", filesave=True, db="alphafold"
+    )
 
     assert os.path.exists(os.path.join(tmpdir, "p0a855.cif"))
     assert os.path.exists(os.path.join(tmpdir, "p0a855.pdb"))

--- a/profet/profet.py
+++ b/profet/profet.py
@@ -100,7 +100,10 @@ class Fetcher:
 
         # If the file is already downloaded then use that, otherwise search in
         # the PDB or alphafold databases
-        if uniprot_id in cache and os.path.splitext(cache[uniprot_id])[1] == filetype:
+        if (
+            uniprot_id in cache
+            and os.path.splitext(cache[uniprot_id])[1] == filetype
+        ):
             filename = cache[uniprot_id]
             with open(filename) as infile:
                 filedata = infile.read()

--- a/profet/profet.py
+++ b/profet/profet.py
@@ -41,6 +41,14 @@ class Fetcher:
             available_db.append("alphafold")
         return available_db
 
+    def cache(self) -> PDBFileCache:
+        """
+        Returns:
+            The PDB file cache
+
+        """
+        return PDBFileCache(directory=self.save_directory)
+
     def file_from_db(
         self,
         prot_id: str,
@@ -92,7 +100,7 @@ class Fetcher:
 
         # If the file is already downloaded then use that, otherwise search in
         # the PDB or alphafold databases
-        if uniprot_id in cache:
+        if uniprot_id in cache and os.path.splitext(cache[uniprot_id])[1] == filetype:
             filename = cache[uniprot_id]
             with open(filename) as infile:
                 filedata = infile.read()


### PR DESCRIPTION
If a pdb file has already been downloaded and a cif file from the same entry is requested then download it.

Added a test and a convenience function for accessing the cache from the fetcher

This fixes #39 